### PR TITLE
support for allennlp==1.3.0

### DIFF
--- a/udify/modules/bert_pretrained.py
+++ b/udify/modules/bert_pretrained.py
@@ -17,7 +17,7 @@ from pytorch_pretrained_bert.modeling import BertModel, BertConfig
 from allennlp.common.util import pad_sequence_to_length
 from allennlp.modules.token_embedders import TokenEmbedder
 from allennlp.data.vocabulary import Vocabulary
-from allennlp.data.tokenizers.token import Token
+from allennlp.data.tokenizers import Token
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 from allennlp.nn import util
 


### PR DESCRIPTION
It seems overlooked on PR #1. https://github.com/allenai/allennlp/pull/4842 reminds us now.